### PR TITLE
Bindings support

### DIFF
--- a/LLManager.h
+++ b/LLManager.h
@@ -13,4 +13,6 @@
 + (BOOL)launchAtLogin;
 + (void)setLaunchAtLogin:(BOOL)value;
 
+@property (assign) BOOL launchAtLogin;
+
 @end

--- a/LLManager.m
+++ b/LLManager.m
@@ -38,4 +38,16 @@
     }
 }
 
+#pragma mark - Bindings support
+
+- (BOOL)launchAtLogin {
+    return [[self class] launchAtLogin];
+}
+
+- (void)setLaunchAtLogin:(BOOL)launchAtLogin {
+    [self willChangeValueForKey:@"launchAtLogin"];
+    [[self class] setLaunchAtLogin:launchAtLogin];
+    [self didChangeValueForKey:@"launchAtLogin"];
+}
+
 @end

--- a/LaunchAtLoginHelper.xcodeproj/project.pbxproj
+++ b/LaunchAtLoginHelper.xcodeproj/project.pbxproj
@@ -97,7 +97,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = LLH;
-				LastUpgradeCheck = 0430;
+				LastUpgradeCheck = 0450;
 				ORGANIZATIONNAME = "David Keegan";
 			};
 			buildConfigurationList = 734C378E15414CE200994189 /* Build configuration list for PBXProject "LaunchAtLoginHelper" */;
@@ -146,6 +146,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -173,6 +174,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_C_LANGUAGE_STANDARD = gnu99;

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,11 @@ Once this is done use `LLManager` to enable and disable launching at login! [**L
 ```
 
 # Bindings
+<<<<<<< HEAD
 The `LLManager` class supports KVO and Cocoa Bindings. This allows a completely code-free implementaion of this class. To get started, open the Interface Builder document in which you plan to create a login toggle. Drag a generic `NSObject` from the Utilities pane, and drop it onto your canvas. Select the newly created object, and open the Identity inspector tab in the Utilities pane. Change the class from `NSObject` to `LLManager`. Now, select to your login toggle (checkbox) and open the Bindings inspector in the Utilities pane. Expand `Value`, check the "Bind to", and select the name of the `LLManager` object you created earlier. Set the key path to `self.launchAtLogin`. You're done!
+=======
+The `LLManager` class supports KVO and Cocoa Bindings. This allows for a completely code-free implementaion of this class. To get started, open the Interface Builder document in which you plan to create a login toggle. Drag a generic `NSObject` from the Utilities pane, and drop it onto your canvas. Select the newly created object, and open the Identity inspector tab in the Utilities pane. Change the class from `NSObject` to `LLManager`. Now, select to your login toggle (checkbox) and open the Bindings inspector in the Utilities pane. Expand `Value`, check the "Bind to", and select the name of the `LLManager` object you created earlier. Set the key path to `self.launchAtLogin`. You're done!
+>>>>>>> add note to readme
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,9 @@ Once this is done use `LLManager` to enable and disable launching at login! [**L
 [LLManager setLaunchAtLogin:YES] // set the app to launch at login
 ```
 
+# Bindings
+The `LLManager` class supports KVO and Cocoa Bindings. This allows a completely code-free implementaion of this class. To get started, open the Interface Builder document in which you plan to create a login toggle. Drag a generic `NSObject` from the Utilities pane, and drop it onto your canvas. Select the newly created object, and open the Identity inspector tab in the Utilities pane. Change the class from `NSObject` to `LLManager`. Now, select to your login toggle (checkbox) and open the Bindings inspector in the Utilities pane. Expand `Value`, check the "Bind to", and select the name of the `LLManager` object you created earlier. Set the key path to `self.launchAtLogin`. You're done!
+
 ---
 
 Special thanks to [Curtis Hard](http://www.geekygoodness.com) for offering some much needed advice on this project.


### PR DESCRIPTION
Sorry for the delay on this one. I had forgotten to submit a pull request. ;)

As per the commit notes:

> Interface Builder support can be achieved by adding a generic NSObject
> in IB, then by changing the class to `LLManager`. Then the
> `launchAtLogin` property can be bound.
