### PR TITLE
Check if scheme can be opened before opening

### DIFF
--- a/LaunchAtLoginHelper/LLHAppDelegate.m
+++ b/LaunchAtLoginHelper/LLHAppDelegate.m
@@ -11,15 +11,31 @@
 
 @implementation LLHAppDelegate
 
-- (void)applicationDidFinishLaunching:(NSNotification *)notification{
-    // Call the scheme to launch the app
-    NSString *scheme = [NSString stringWithFormat:@"%@://", LLURLScheme];
-    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:scheme]];
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
     
-    // Call the app again this time with `launchedAtLogin` so it knows how it was launched
-    NSString *schemeLaunchedAtLogin = 
-    [NSString stringWithFormat:@"%@://launchedAtLogin", LLURLScheme];
-    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:schemeLaunchedAtLogin]];    
+    // The scheme to launch the app
+    NSString *scheme = [NSString stringWithFormat:@"%@://", LLURLScheme];
+    NSURL *schemeURL = [NSURL URLWithString:scheme];
+    
+    // Get URL for app that responds to scheme
+    NSURL *appURL = [[NSWorkspace sharedWorkspace] URLForApplicationToOpenURL:schemeURL];
+
+    // Check if app exists
+    if(appURL) {
+        
+        // App exists, run it
+        [[NSWorkspace sharedWorkspace] openURL:schemeURL];
+        
+        // Call the app again this time with `launchedAtLogin` so it knows how it was launched
+        NSString *schemeLaunchedAtLogin = [NSString stringWithFormat:@"%@://launchedAtLogin", LLURLScheme];
+        [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:schemeLaunchedAtLogin]];
+        
+    } else {
+        
+        // Log that the app couldn't be found
+        NSLog(@"No app responds to %@, helper should be removed from launchd", scheme);
+        
+    }
     [NSApp terminate:self];
 }
 


### PR DESCRIPTION
This commit adds a check to the helper that will retrieve the path to the app that responds to the given scheme. Failure to retrieve this path means the app does not exist on the system and the scheme shouldn't be called.

It's a fix for a relatively rare case when the container app has been moved to the Trash, but the helper is still in launchd. The OS will throw errors stating the scheme can't be opened.
